### PR TITLE
Feat/#21 차단한 사용자가 보낸 메세지 차단 & 채널 소유자가 채널을 나갈때 소유자 권한 넘기기

### DIFF
--- a/backend/src/api/channel/channel.controller.ts
+++ b/backend/src/api/channel/channel.controller.ts
@@ -78,6 +78,18 @@ export class ChannelController {
     return this.channelService.getOutChannel(userId, channelId);
   }
 
+  @Get(':channelId')
+  @ApiOperation({ summary: '특정 채널 메세지 불러오기' })
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  getChannelMessages(
+    @Req() req,
+    @Param('channelId', ParseUUIDPipe) channelId: string,
+  ) {
+    const userId = req.user.id;
+    return this.channelService.getChannelMessages(userId, channelId);
+  }
+
   @Get(':channelId/member')
   @ApiOperation({ summary: '특정 채널에 참여한 멤버 보기' })
   findParticipants(@Param('channelId', ParseUUIDPipe) channelId: string) {

--- a/backend/src/api/channel/channel.module.ts
+++ b/backend/src/api/channel/channel.module.ts
@@ -10,6 +10,7 @@ import { ChannelMessage } from '../../core/channel/channel-message.entity';
 import { ChannelMemberRepository } from '../../core/channel/channel-member.repository';
 import { ChannelMessageRepository } from '../../core/channel/channel-message.repository';
 import { UserRepository } from '../../core/user/user.repository';
+import { BlockRepository } from '../../core/block/block.repository';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { UserRepository } from '../../core/user/user.repository';
       ChannelMemberRepository,
       ChannelMessageRepository,
       UserRepository,
+      BlockRepository,
     ]),
   ],
   controllers: [ChannelController],

--- a/backend/src/api/channel/channel.service.ts
+++ b/backend/src/api/channel/channel.service.ts
@@ -152,6 +152,7 @@ export class ChannelService {
     }
     await this.channelMemberRepository.update(joinChannels.id, {
       leftAt: () => 'CURRENT_TIMESTAMP',
+      roleInChannel: RoleInChannel.NORMAL,
     });
     if (joinChannels.roleInChannel === RoleInChannel.OWNER) {
       await this.changeChannelOwner(channelId);

--- a/backend/src/api/dm/dm.controller.ts
+++ b/backend/src/api/dm/dm.controller.ts
@@ -30,15 +30,16 @@ export class DmController {
   @ApiBearerAuth()
   getDmRooms(@Request() request): Promise<DmRoom[]> {
     const userId = request.user.id;
-    return this.dmService.getDmRooms(userId);
+    return this.dmService.getDmRoomsByParticipant(userId);
   }
 
-  @Get('msg')
+  @Get(':roomId')
   @ApiOperation({ summary: '특정 dm방의 메세지 목록' })
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
-  getDms(@Query('roomId') roomId: any): Promise<Dm[]> {
-    return this.dmService.getDms(roomId);
+  getDms(@Request() request, @Param('roomId') roomId: string): Promise<Dm[]> {
+    const userId = request.user.id;
+    return this.dmService.getDms(roomId, userId);
   }
 
   @Post(':invitedUserId')

--- a/backend/src/api/dm/dm.module.ts
+++ b/backend/src/api/dm/dm.module.ts
@@ -10,6 +10,7 @@ import { DmRoomRepository } from '../../core/dm/dm-room.repository';
 import { UserRepository } from '../../core/user/user.repository';
 import { SocketModule } from '../../core/socket/socket.module';
 import { DmGateway } from './dm.gateway';
+import { BlockRepository } from '../../core/block/block.repository';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { DmGateway } from './dm.gateway';
       DmRepository,
       DmRoomRepository,
       UserRepository,
+      BlockRepository,
     ]),
   ],
   controllers: [DmController],

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -128,18 +128,6 @@ export class UserController {
     return this.userService.findChannelByParticipant(userId);
   }
 
-  @Get('/:banId/ban')
-  @ApiOperation({ summary: '어드민 권한을 가진 유저가 일반 사용자를 차단' })
-  @UseGuards(AuthGuard('jwt'))
-  @ApiBearerAuth()
-  blockUserFromService(@Req() req, @Param('banId') banId: string) {
-    if (!isUUID(banId)) {
-      throw new BadRequestException('id가 uuid가 아님');
-    }
-    const userId = req.user.id;
-    return this.userService.blockUserFromService(userId, banId);
-  }
-
   @Get(':id')
   @ApiOperation({ summary: '특정 유저 프로필 조회' })
   @ApiParam({

--- a/backend/src/api/user/user.service.ts
+++ b/backend/src/api/user/user.service.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  BadRequestException,
-  ForbiddenException,
-} from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../../core/user/user.entity';
 import { UserRepository } from '../../core/user/user.repository';
@@ -12,7 +8,6 @@ import { Like, IsNull, In, Not } from 'typeorm';
 import { FriendRespository } from '../../core/friend/friend.repository';
 import { Friend } from '../../core/friend/friend.entity';
 import { BlockRepository } from '../../core/block/block.repository';
-import { UserRole } from '../../enum/user-role.enum';
 import { ChannelRepository } from '../../core/channel/channel.repository';
 import { ChannelMemberRepository } from '../../core/channel/channel-member.repository';
 import { GameHistoryRepository } from '../../core/game/game-history.repository';
@@ -181,34 +176,8 @@ export class UserService {
     return { success: true };
   }
 
-  async blockUserFromService(userId: string, banId: string) {
-    const user = await this.findUserById(userId);
-    if (!(user.role === UserRole.OWNER || user.role === UserRole.MODERATOR)) {
-      throw new ForbiddenException('권한이 없습니다');
-    }
-    if (userId === banId) {
-      throw new BadRequestException('userId === blockId');
-    }
-    const banUser = await this.findUserById(banId);
-    if (!banUser) {
-      throw new BadRequestException('존재하지 않는 유저');
-    }
-    if (banUser.role === UserRole.OWNER) {
-      throw new ForbiddenException('권한이 없습니다');
-    } else if (banUser.role === UserRole.BAN) {
-      throw new BadRequestException('이미 정지된 유저입니다');
-    }
-    await this.userRepository.update(banUser.id, {
-      role: UserRole.BAN,
-    });
-    return { success: true };
-  }
-
   async findChannelByParticipant(userId: string) {
-    const user = await this.findUserById(userId);
-    if (user.role === UserRole.OWNER || user.role === UserRole.MODERATOR) {
-      return this.channelRepository.find();
-    }
+    // const user = await this.findUserById(userId);
     const joinChannels = await this.channelMemberRepository.find({
       relations: ['userId', 'channelId'],
       where: {

--- a/backend/src/api/user/user.service.ts
+++ b/backend/src/api/user/user.service.ts
@@ -12,6 +12,7 @@ import { ChannelRepository } from '../../core/channel/channel.repository';
 import { ChannelMemberRepository } from '../../core/channel/channel-member.repository';
 import { GameHistoryRepository } from '../../core/game/game-history.repository';
 import { GameHistory } from '../../core/game/game-history.entity';
+import { WinLose } from 'src/enum/win-lose.enum';
 
 @Injectable()
 export class UserService {
@@ -203,6 +204,10 @@ export class UserService {
       relations: ['userId', 'gameRoomId'],
       where: { userId: { id: userId } },
     });
+    const userWins = await this.gameHistoryRepository.find({
+      relations: ['userId', 'gameRoomId'],
+      where: { userId: { id: userId }, win: WinLose.WIN },
+    });
     const gameRooms = userGameHistory.map(
       (gameRoom) => gameRoom?.gameRoomId?.id,
     );
@@ -248,6 +253,10 @@ export class UserService {
       }),
     );
     const gameHistories = Array.from(gameHistory.values());
-    return { ...user, matchHistory: gameHistories };
+    return {
+      ...user,
+      winLose: { allGames: userGameHistory.length, wins: userWins.length },
+      matchHistory: gameHistories,
+    };
   }
 }

--- a/backend/src/core/block/block.repository.ts
+++ b/backend/src/core/block/block.repository.ts
@@ -1,4 +1,4 @@
-import { Repository } from 'typeorm';
+import { Repository, IsNull, Not } from 'typeorm';
 import { Block } from './block.entity';
 import { CustomRepository } from '../../typeorm-ex.decorator';
 import { User } from '../user/user.entity';
@@ -12,5 +12,20 @@ export class BlockRepository extends Repository<Block> {
     });
     await this.save(block);
     return block;
+  }
+
+  async didUserBlockOther(userId: string, otherId: string) {
+    return await this.findOne({
+      relations: ['userId', 'blockedUserId'],
+      where: {
+        userId: {
+          id: userId,
+        },
+        blockedUserId: {
+          id: otherId,
+        },
+        blockAt: Not(IsNull()),
+      },
+    });
   }
 }

--- a/backend/src/core/block/block.repository.ts
+++ b/backend/src/core/block/block.repository.ts
@@ -14,6 +14,18 @@ export class BlockRepository extends Repository<Block> {
     return block;
   }
 
+  async getBlockUsers(userId: string) {
+    return await this.find({
+      relations: ['userId', 'blockedUserId'],
+      where: {
+        userId: {
+          id: userId,
+        },
+        blockAt: Not(IsNull()),
+      },
+    });
+  }
+
   async didUserBlockOther(userId: string, otherId: string) {
     return await this.findOne({
       relations: ['userId', 'blockedUserId'],

--- a/backend/src/core/channel/channel-member.repository.ts
+++ b/backend/src/core/channel/channel-member.repository.ts
@@ -1,4 +1,4 @@
-import { Repository, IsNull, LessThan } from 'typeorm';
+import { Repository, IsNull, LessThan, Not } from 'typeorm';
 import { ChannelMember } from './channel-member.entity';
 import { CustomRepository } from '../../typeorm-ex.decorator';
 import { User } from '../user/user.entity';
@@ -47,6 +47,36 @@ export class ChannelMemberRepository extends Repository<ChannelMember> {
       relations: ['userId', 'channelId'],
       where: {
         userId: { id: userId },
+        channelId: { id: channelId, deletedAt: IsNull() },
+      },
+    });
+  }
+
+  async getChannelAdministrators(channelId: string) {
+    return await this.find({
+      relations: ['userId', 'channelId'],
+      order: {
+        createdAt: 'ASC',
+      },
+      where: {
+        leftAt: IsNull(),
+        banEndAt: IsNull() || LessThan(new Date()),
+        roleInChannel: RoleInChannel.ADMINISTRATOR,
+        channelId: { id: channelId, deletedAt: IsNull() },
+      },
+    });
+  }
+
+  async getChannelMembersExcludeOwner(channelId: string) {
+    return await this.find({
+      relations: ['userId', 'channelId'],
+      order: {
+        createdAt: 'ASC',
+      },
+      where: {
+        leftAt: IsNull(),
+        banEndAt: IsNull() || LessThan(new Date()),
+        roleInChannel: Not(RoleInChannel.OWNER),
         channelId: { id: channelId, deletedAt: IsNull() },
       },
     });

--- a/backend/src/core/channel/channel-message.repository.ts
+++ b/backend/src/core/channel/channel-message.repository.ts
@@ -1,6 +1,43 @@
-import { Repository } from 'typeorm';
+import { Repository, In, Not } from 'typeorm';
 import { ChannelMessage } from './channel-message.entity';
 import { CustomRepository } from '../../typeorm-ex.decorator';
 
 @CustomRepository(ChannelMessage)
-export class ChannelMessageRepository extends Repository<ChannelMessage> {}
+export class ChannelMessageRepository extends Repository<ChannelMessage> {
+  async getChannelMessages(
+    userId: string,
+    channelId: string,
+    blockUsers: any[],
+  ) {
+    if (blockUsers.length > 0) {
+      const blockUserIds: string[] = blockUsers.map(
+        (blockUser) => blockUser.blockedUserId.id,
+      );
+      return await this.find({
+        relations: ['channelId', 'sendUserId'],
+        order: {
+          createdAt: 'ASC',
+        },
+        where: {
+          channelId: {
+            id: channelId,
+          },
+          sendUserId: {
+            id: Not(In(blockUserIds)),
+          },
+        },
+      });
+    }
+    return await this.find({
+      relations: ['channelId', 'sendUserId'],
+      order: {
+        createdAt: 'ASC',
+      },
+      where: {
+        channelId: {
+          id: channelId,
+        },
+      },
+    });
+  }
+}

--- a/backend/src/core/channel/channel.entity.ts
+++ b/backend/src/core/channel/channel.entity.ts
@@ -1,8 +1,7 @@
-import { Column, Entity, Unique } from 'typeorm';
+import { Column, Entity } from 'typeorm';
 import { Base } from '../Base.entity';
 
 @Entity()
-@Unique(['channelName'])
 export class Channel extends Base {
   @Column({
     type: 'varchar',

--- a/backend/src/core/channel/channel.repository.ts
+++ b/backend/src/core/channel/channel.repository.ts
@@ -1,4 +1,4 @@
-import { Repository, IsNull } from 'typeorm';
+import { Repository, IsNull, Not, In } from 'typeorm';
 import { Channel } from './channel.entity';
 import { CustomRepository } from '../../typeorm-ex.decorator';
 import { CreateChannelDto } from '../../api/channel/dto/create-channel.dto';
@@ -6,15 +6,21 @@ import { CreateChannelDto } from '../../api/channel/dto/create-channel.dto';
 @CustomRepository(Channel)
 export class ChannelRepository extends Repository<Channel> {
   async getChannels(joinChannelsId) {
-    return await this.createQueryBuilder('channel')
-      .where(
-        'channel.id NOT IN (:...ids) and channel.is_public = :isPublic and channel.deleted_at IS NULL',
-        {
-          ids: joinChannelsId,
+    if (joinChannelsId.length > 0) {
+      return await this.find({
+        where: {
+          id: Not(In(joinChannelsId)),
           isPublic: true,
+          deletedAt: IsNull(),
         },
-      )
-      .getMany();
+      });
+    }
+    return await this.find({
+      where: {
+        isPublic: true,
+        deletedAt: IsNull(),
+      },
+    });
   }
 
   async makeChannel(createChannelData: CreateChannelDto) {

--- a/backend/src/core/dm/dm-room.repository.ts
+++ b/backend/src/core/dm/dm-room.repository.ts
@@ -14,12 +14,21 @@ export class DmRoomRepository extends Repository<DmRoom> {
     return dmRoom;
   }
 
-  async getDmRooms(userId: string): Promise<DmRoom[]> {
+  async getDmRoomsByParticipant(userId: string): Promise<DmRoom[]> {
     const dmRooms = await this.find({
       relations: ['userId', 'invitedUserId'],
       where: [{ userId: { id: userId } }, { invitedUserId: { id: userId } }],
     });
     return dmRooms;
+  }
+
+  async getDmRoomByRoomId(roomId: string): Promise<DmRoom> {
+    return await this.findOne({
+      relations: ['userId', 'invitedUserId'],
+      where: {
+        id: roomId,
+      },
+    });
   }
 
   async findAndCountByParticipants(

--- a/backend/src/core/dm/dm.repository.ts
+++ b/backend/src/core/dm/dm.repository.ts
@@ -1,6 +1,52 @@
-import { Repository } from 'typeorm';
+import { Repository, LessThan } from 'typeorm';
 import { Dm } from './dm.entity';
 import { CustomRepository } from '../../typeorm-ex.decorator';
 
 @CustomRepository(Dm)
-export class DmRepository extends Repository<Dm> {}
+export class DmRepository extends Repository<Dm> {
+  async getDms(
+    roomId: string,
+    userId: string,
+    otherId: string,
+    blockAt: Date | null,
+  ) {
+    if (blockAt) {
+      return await this.find({
+        relations: ['dmRoomId', 'sendUserId'],
+        order: {
+          createdAt: 'ASC',
+        },
+        where: [
+          {
+            dmRoomId: {
+              id: roomId,
+            },
+            sendUserId: {
+              id: otherId,
+            },
+            createdAt: LessThan(blockAt),
+          },
+          {
+            dmRoomId: {
+              id: roomId,
+            },
+            sendUserId: {
+              id: userId,
+            },
+          },
+        ],
+      });
+    }
+    return await this.find({
+      relations: ['dmRoomId', 'sendUserId'],
+      order: {
+        createdAt: 'ASC',
+      },
+      where: {
+        dmRoomId: {
+          id: roomId,
+        },
+      },
+    });
+  }
+}

--- a/frontend/pages/dm/[room_id].tsx
+++ b/frontend/pages/dm/[room_id].tsx
@@ -22,7 +22,7 @@ export default function Dm() {
     console.log(loginUser);
     if (roomId) {
       axios
-        .get(`/server/api/dm/msg?roomId=${roomId}`)
+        .get(`/server/api/dm/${roomId}`)
         .then(function (response) {
           const dmList = response.data;
           console.log(dmList);
@@ -31,10 +31,16 @@ export default function Dm() {
           dmSocket.emit("dmRoom", roomId);
           dmSocket.on(`drawDm`, (message) => {
             console.log(message);
-            setMsgList((current: any) => {
-              current.push(message);
-              return [...current];
-            });
+            if (
+              !(
+                loginUser.id !== message.sendUserId.id &&
+                message.isSendUserBlocked
+              )
+            )
+              setMsgList((current: any) => {
+                current.push(message);
+                return [...current];
+              });
           });
 
           router.events.on("routeChangeStart", () => {


### PR DESCRIPTION
## Description
차단한 사용자에게서 온 채팅을 프론트에 보내지 않습니다.

## done
### channel & dm 에서 차단한 사용자가 보낸 메세지 막기
- `GET dm/msg?roomId=` 수정
  - `GET dm/{roomId}` 로 수정
  - 특정 dm방에서 저장된 메세지 중 상대 유저가 차단된 시각 이후에 보낸 메세지는 보내지 않음
- `GET channel/{channelId}` 추가
  - 특정 채널에서 저장된 메세지 중 메세지를 보낸 유저가 차단된 유저면 메세지를 보내지 않음
  - dm과 달리 차단 시각까지 고려하지 않음
- 프론트 실시간 채팅
  - 차단한 유저가 보낸 실시간 메세지 막음
### 채널 소유자가 채널을 나간 경우
- `PACTH channel/{channelId}` 변경
- 관리자 중 가장 먼저 들어온 사람에게 소유자 권한 넘김
- 관리자가 없다면 일반 유저 중 가장 먼저 들어온 사람에게 넘김
- 아무도 없다면 소유자가 채널을 나감과 동시에 채널을 삭제
### user
- user.role 사용하는 부분 제거
- 특정유저 정보에 승률 (`winLose`) 항목 추가