### PR TITLE
Feat/#24

### DIFF
--- a/backend/src/api/auth/auth.service.ts
+++ b/backend/src/api/auth/auth.service.ts
@@ -27,7 +27,7 @@ export class AuthService {
 
     const newUser = this.userRepository.create({ username: username });
     const saveUser = await this.userRepository.save(newUser);
-    return { id: saveUser.id, firstLogin: true };
+    return { id: saveUser.id, username: saveUser.username, firstLogin: true };
   }
 
   verifyToken(jwt: string): any {

--- a/backend/src/api/channel/channel.controller.ts
+++ b/backend/src/api/channel/channel.controller.ts
@@ -200,7 +200,6 @@ export class ChannelController {
   @ApiOperation({ summary: '특정 채널에 사용자 초대하기' })
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
-  @ApiBody({ type: ChangeRoleInChannelDto })
   inviteUser(
     @Req() req,
     @Param('channelId') channelId: string,

--- a/backend/src/api/channel/channel.controller.ts
+++ b/backend/src/api/channel/channel.controller.ts
@@ -17,6 +17,8 @@ import { CreateChannelDto } from './dto/create-channel.dto';
 import { ChannelPasswordDto } from './dto/channel-password.dto';
 import { RestrictChannelDto } from './dto/restrict-channel.dto';
 import { ChangeRoleInChannelDto } from './dto/change-role-in-channel.dto';
+import { isUUID } from 'class-validator';
+import { BadRequestException } from '@nestjs/common';
 
 @Controller('channel')
 @ApiTags('channel')
@@ -49,6 +51,9 @@ export class ChannelController {
     @Req() req,
     @Param('channelId', ParseUUIDPipe) channelId: string,
   ) {
+    if (!isUUID(channelId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = req.user.id;
     return this.channelService.deleteChannel(userId, channelId);
   }
@@ -62,6 +67,9 @@ export class ChannelController {
     @Param('channelId', ParseUUIDPipe) channelId: string,
     @Body() channelPassword: ChannelPasswordDto,
   ) {
+    if (!isUUID(channelId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = req.user.id;
     return this.channelService.joinChannels(userId, channelId, channelPassword);
   }
@@ -74,6 +82,9 @@ export class ChannelController {
     @Req() req,
     @Param('channelId', ParseUUIDPipe) channelId: string,
   ) {
+    if (!isUUID(channelId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = req.user.id;
     return this.channelService.getOutChannel(userId, channelId);
   }
@@ -86,6 +97,9 @@ export class ChannelController {
     @Req() req,
     @Param('channelId', ParseUUIDPipe) channelId: string,
   ) {
+    if (!isUUID(channelId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = req.user.id;
     return this.channelService.getChannelMessages(userId, channelId);
   }
@@ -93,6 +107,9 @@ export class ChannelController {
   @Get(':channelId/member')
   @ApiOperation({ summary: '특정 채널에 참여한 멤버 보기' })
   findParticipants(@Param('channelId', ParseUUIDPipe) channelId: string) {
+    if (!isUUID(channelId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     return this.channelService.findParticipants(channelId);
   }
 
@@ -106,6 +123,9 @@ export class ChannelController {
     @Param('channelId', ParseUUIDPipe) channelId: string,
     @Body() channelPassword: ChannelPasswordDto,
   ) {
+    if (!isUUID(channelId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = req.user.id;
     return this.channelService.changePassword(
       userId,
@@ -127,6 +147,9 @@ export class ChannelController {
     @Param('targetId', ParseUUIDPipe) targetId: string,
     @Body() restrictChannelDto: RestrictChannelDto,
   ) {
+    if (!isUUID(channelId) || !isUUID(targetId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = req.user.id;
     return this.channelService.muteUser(
       userId,
@@ -149,6 +172,9 @@ export class ChannelController {
     @Param('targetId', ParseUUIDPipe) targetId: string,
     @Body() restrictChannelDto: RestrictChannelDto,
   ) {
+    if (!isUUID(channelId) || !isUUID(targetId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = req.user.id;
     return this.channelService.banUser(
       userId,
@@ -157,24 +183,6 @@ export class ChannelController {
       restrictChannelDto.limitedTime,
     );
   }
-
-  //   @Patch(':channelId/block/:targetId')
-  //   @ApiOperation({ summary: '채널 어드민 유저가 특정 유저를 강퇴' })
-  //   @UseGuards(AuthGuard('jwt'))
-  //   @ApiBearerAuth()
-  //   @ApiBody({ type: RestrictChannelDto })
-  //   blockUserFromChannel(
-  //     @Req() req,
-  //     @Param('channelId', ParseUUIDPipe) channelId: string,
-  //     @Param('targetId', ParseUUIDPipe) targetId: string,
-  //   ) {
-  //     const userId = req.user.id;
-  //     return this.channelService.blockUserFromChannel(
-  //       userId,
-  //       channelId,
-  //       targetId,
-  //     );
-  //   }
 
   @Patch(':channelId/role/:targetId')
   @ApiOperation({ summary: '채널 어드민 유저가 특정 유저 권한을 부여/제거' })
@@ -187,6 +195,9 @@ export class ChannelController {
     @Param('targetId') targetId: string,
     @Body() changeRole: ChangeRoleInChannelDto,
   ) {
+    if (!isUUID(channelId) || !isUUID(targetId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = req.user.id;
     return this.channelService.changeRoleInChannel(
       userId,
@@ -205,6 +216,9 @@ export class ChannelController {
     @Param('channelId') channelId: string,
     @Param('targetId') targetId: string,
   ) {
+    if (!isUUID(channelId) || !isUUID(targetId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = req.user.id;
     return this.channelService.inviteUser(userId, channelId, targetId);
   }

--- a/backend/src/api/channel/channel.controller.ts
+++ b/backend/src/api/channel/channel.controller.ts
@@ -195,4 +195,18 @@ export class ChannelController {
       changeRole,
     );
   }
+
+  @Post(':channelId/invite/:targetId')
+  @ApiOperation({ summary: '특정 채널에 사용자 초대하기' })
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  @ApiBody({ type: ChangeRoleInChannelDto })
+  inviteUser(
+    @Req() req,
+    @Param('channelId') channelId: string,
+    @Param('targetId') targetId: string,
+  ) {
+    const userId = req.user.id;
+    return this.channelService.inviteUser(userId, channelId, targetId);
+  }
 }

--- a/backend/src/api/channel/channel.controller.ts
+++ b/backend/src/api/channel/channel.controller.ts
@@ -158,26 +158,26 @@ export class ChannelController {
     );
   }
 
-  @Patch(':channelId/block/:targetId')
-  @ApiOperation({ summary: '채널 어드민 유저가 특정 유저를 강퇴' })
-  @UseGuards(AuthGuard('jwt'))
-  @ApiBearerAuth()
-  @ApiBody({ type: RestrictChannelDto })
-  blockUserFromChannel(
-    @Req() req,
-    @Param('channelId', ParseUUIDPipe) channelId: string,
-    @Param('targetId', ParseUUIDPipe) targetId: string,
-  ) {
-    const userId = req.user.id;
-    return this.channelService.blockUserFromChannel(
-      userId,
-      channelId,
-      targetId,
-    );
-  }
+  //   @Patch(':channelId/block/:targetId')
+  //   @ApiOperation({ summary: '채널 어드민 유저가 특정 유저를 강퇴' })
+  //   @UseGuards(AuthGuard('jwt'))
+  //   @ApiBearerAuth()
+  //   @ApiBody({ type: RestrictChannelDto })
+  //   blockUserFromChannel(
+  //     @Req() req,
+  //     @Param('channelId', ParseUUIDPipe) channelId: string,
+  //     @Param('targetId', ParseUUIDPipe) targetId: string,
+  //   ) {
+  //     const userId = req.user.id;
+  //     return this.channelService.blockUserFromChannel(
+  //       userId,
+  //       channelId,
+  //       targetId,
+  //     );
+  //   }
 
   @Patch(':channelId/role/:targetId')
-  @ApiOperation({ summary: '채널/웹 어드민 유저가 특정 유저 권한을 부여/제거' })
+  @ApiOperation({ summary: '채널 어드민 유저가 특정 유저 권한을 부여/제거' })
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
   @ApiBody({ type: ChangeRoleInChannelDto })

--- a/backend/src/api/channel/channel.service.ts
+++ b/backend/src/api/channel/channel.service.ts
@@ -169,6 +169,16 @@ export class ChannelService {
     if (!channel) {
       throw new BadRequestException('채널 정보가 잘못됨');
     }
+    const joinChannel =
+      await this.channelMemberRepository.findChannelJoinCurrently(
+        userId,
+        channelId,
+      );
+    if (!joinChannel) {
+      throw new BadRequestException(
+        '해당 채널 메세지 목록을 볼 수 있는 권한이 없습니다',
+      );
+    }
     const blockUsers = await this.blockRepository.getBlockUsers(userId);
     return await this.channelMessageRepository.getChannelMessages(
       userId,

--- a/backend/src/api/channel/channel.service.ts
+++ b/backend/src/api/channel/channel.service.ts
@@ -358,10 +358,11 @@ export class ChannelService {
   async inviteUser(userId: string, channelId: string, targetId: string) {
     const target = await this.userRepository.findOneBy({ id: targetId });
     const channel = await this.channelRepository.findOneBy({ id: channelId });
-    const userInChannel = this.channelMemberRepository.findChannelJoinCurrently(
-      userId,
-      channelId,
-    );
+    const userInChannel =
+      await this.channelMemberRepository.findChannelJoinCurrently(
+        userId,
+        channelId,
+      );
     if (!target || !channel || !userInChannel) {
       throw new BadRequestException(
         '존재하지 않는 채널이거나 존재하지 않는 사용자',

--- a/backend/src/api/channel/channel.service.ts
+++ b/backend/src/api/channel/channel.service.ts
@@ -80,10 +80,11 @@ export class ChannelService {
     if (!channel) {
       throw new BadRequestException('존재하지 않는 채널');
     }
-    const joinChannels = await this.channelMemberRepository.findChannelHaveJoin(
-      userId,
-      channelId,
-    );
+    const joinChannels =
+      await this.channelMemberRepository.findChannelHaveJoinOrInvite(
+        userId,
+        channelId,
+      );
     if (
       joinChannels &&
       (joinChannels.roleInChannel === RoleInChannel.BLOCK ||
@@ -91,15 +92,16 @@ export class ChannelService {
     ) {
       throw new BadRequestException('채널로부터 차단 당했습니다');
     }
-    if (joinChannels && !joinChannels.leftAt) {
+    if (joinChannels && joinChannels.joinAt && !joinChannels.leftAt) {
       throw new BadRequestException('이미 참여한 채널');
     }
     // 비밀번호 암호화 검증 추가
     if (channel.password && channel.password !== channelPassword.password) {
       throw new BadRequestException('비밀번호가 틀렸습니다');
     }
-    if (joinChannels && joinChannels.leftAt) {
+    if (joinChannels) {
       await this.channelMemberRepository.update(joinChannels.id, {
+        joinAt: () => 'CURRENT_TIMESTAMP',
         leftAt: null,
       });
       return joinChannels;
@@ -354,5 +356,45 @@ export class ChannelService {
       roleInChannel: changeRole.roleInChannel,
     });
     return { success: true };
+  }
+
+  async inviteUser(userId: string, channelId: string, targetId: string) {
+    const target = await this.userRepository.findOneBy({ id: targetId });
+    const channel = await this.channelRepository.findOneBy({ id: channelId });
+    if (!target && !channel) {
+      throw new BadRequestException(
+        '존재하지 않는 채널이거나 존재하지 않는 사용자',
+      );
+    }
+    const joinChannels =
+      await this.channelMemberRepository.findChannelHaveJoinOrInvite(
+        targetId,
+        channelId,
+      );
+    if (
+      joinChannels &&
+      (joinChannels.roleInChannel === RoleInChannel.BLOCK ||
+        joinChannels.banEndAt >= new Date())
+    ) {
+      throw new BadRequestException('채널로부터 차단 당했습니다');
+    }
+    if (joinChannels && (!joinChannels.leftAt || !joinChannels.joinAt)) {
+      throw new BadRequestException(
+        '이미 사용자가 채널에 있거나 초대된 상태입니다.',
+      );
+    }
+    if (joinChannels) {
+      await this.channelMemberRepository.update(joinChannels.id, {
+        joinAt: null,
+      });
+      return joinChannels;
+    }
+    const channelMember = this.channelMemberRepository.create({
+      userId: target,
+      channelId: channel,
+      joinAt: null,
+    });
+    await this.channelMemberRepository.save(channelMember);
+    return channelMember;
   }
 }

--- a/backend/src/api/channel/channel.service.ts
+++ b/backend/src/api/channel/channel.service.ts
@@ -91,6 +91,12 @@ export class ChannelService {
     if (joinChannels && joinChannels.joinAt && !joinChannels.leftAt) {
       throw new BadRequestException('이미 참여한 채널');
     }
+    if (
+      (joinChannels && !channel.isPublic && joinChannels.joinAt) ||
+      (!joinChannels && !channel.isPublic)
+    ) {
+      throw new BadRequestException('입장 권한이 없습니다');
+    }
     // 비밀번호 암호화 검증 추가
     if (channel.password && channel.password !== channelPassword.password) {
       throw new BadRequestException('비밀번호가 틀렸습니다');

--- a/backend/src/api/channel/channel.service.ts
+++ b/backend/src/api/channel/channel.service.ts
@@ -85,11 +85,7 @@ export class ChannelService {
         userId,
         channelId,
       );
-    if (
-      joinChannels &&
-      (joinChannels.roleInChannel === RoleInChannel.BLOCK ||
-        joinChannels.banEndAt >= new Date())
-    ) {
+    if (joinChannels && joinChannels.banEndAt >= new Date()) {
       throw new BadRequestException('채널로부터 차단 당했습니다');
     }
     if (joinChannels && joinChannels.joinAt && !joinChannels.leftAt) {
@@ -319,26 +315,27 @@ export class ChannelService {
     );
     await this.channelMemberRepository.update(target.id, {
       banEndAt: banEndAt,
+      leftAt: () => 'CURRENT_TIMESTAMP',
     });
     return { success: true };
   }
 
-  async blockUserFromChannel(
-    userId: string,
-    channelId: string,
-    targetId: string,
-  ) {
-    const target = await this.restirctByChannelAdmin(
-      userId,
-      channelId,
-      targetId,
-    );
-    await this.channelMemberRepository.update(target.id, {
-      leftAt: () => 'CURRENT_TIMESTAMP',
-      roleInChannel: RoleInChannel.BLOCK,
-    });
-    return { success: true };
-  }
+  //   async blockUserFromChannel(
+  //     userId: string,
+  //     channelId: string,
+  //     targetId: string,
+  //   ) {
+  //     const target = await this.restirctByChannelAdmin(
+  //       userId,
+  //       channelId,
+  //       targetId,
+  //     );
+  //     await this.channelMemberRepository.update(target.id, {
+  //       leftAt: () => 'CURRENT_TIMESTAMP',
+  //       roleInChannel: RoleInChannel.BLOCK,
+  //     });
+  //     return { success: true };
+  //   }
 
   async changeRoleInChannel(
     userId: string,
@@ -371,11 +368,7 @@ export class ChannelService {
         targetId,
         channelId,
       );
-    if (
-      joinChannels &&
-      (joinChannels.roleInChannel === RoleInChannel.BLOCK ||
-        joinChannels.banEndAt >= new Date())
-    ) {
+    if (joinChannels && joinChannels.banEndAt >= new Date()) {
       throw new BadRequestException('채널로부터 차단 당했습니다');
     }
     if (joinChannels && (!joinChannels.leftAt || !joinChannels.joinAt)) {

--- a/backend/src/api/channel/channel.service.ts
+++ b/backend/src/api/channel/channel.service.ts
@@ -358,7 +358,11 @@ export class ChannelService {
   async inviteUser(userId: string, channelId: string, targetId: string) {
     const target = await this.userRepository.findOneBy({ id: targetId });
     const channel = await this.channelRepository.findOneBy({ id: channelId });
-    if (!target && !channel) {
+    const userInChannel = this.channelMemberRepository.findChannelJoinCurrently(
+      userId,
+      channelId,
+    );
+    if (!target || !channel || !userInChannel) {
       throw new BadRequestException(
         '존재하지 않는 채널이거나 존재하지 않는 사용자',
       );

--- a/backend/src/api/dm/dm.controller.ts
+++ b/backend/src/api/dm/dm.controller.ts
@@ -1,17 +1,17 @@
 import {
-  Body,
   Controller,
   Get,
   Request,
   Post,
   UseGuards,
-  Query,
   Param,
 } from '@nestjs/common';
 import { DmService } from './dm.service';
 import { DmRoom } from '../../core/dm/dm-room.entity';
 import { Dm } from '../../core/dm/dm.entity';
 import { AuthGuard } from '@nestjs/passport';
+import { isUUID } from 'class-validator';
+import { BadRequestException } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -38,6 +38,9 @@ export class DmController {
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
   getDms(@Request() request, @Param('roomId') roomId: string): Promise<Dm[]> {
+    if (!isUUID(roomId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = request.user.id;
     return this.dmService.getDms(roomId, userId);
   }
@@ -51,6 +54,9 @@ export class DmController {
     @Request() request,
     @Param('invitedUserId') invitedUserId: string,
   ) {
+    if (!isUUID(invitedUserId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = request.user.id;
     return this.dmService.createDmRoom(userId, invitedUserId);
   }

--- a/backend/src/api/dm/dm.service.ts
+++ b/backend/src/api/dm/dm.service.ts
@@ -123,6 +123,11 @@ export class DmService {
     if (!dmRoom) {
       throw new BadRequestException('bad request');
     }
+    if (!(dmRoom.userId.id === userId || dmRoom.invitedUserId.id === userId)) {
+      throw new BadRequestException(
+        '해당 dm 목록을 볼 수 있는 권한이 없습니다',
+      );
+    }
     const otherId =
       userId === dmRoom.userId.id ? dmRoom.invitedUserId.id : dmRoom.userId.id;
     const isBlockUser = await this.blockRepository.didUserBlockOther(

--- a/backend/src/api/game/game.controller.ts
+++ b/backend/src/api/game/game.controller.ts
@@ -5,16 +5,14 @@ import {
   Body,
   Request,
   UseGuards,
-  Query,
-  Param,
 } from '@nestjs/common';
 import { GameService } from './game.service';
 import { GameRoomDto } from '../../core/game/dto/game-room.dto';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBearerAuth, ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
-import { request } from 'http';
-import { Any } from 'typeorm';
+import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
 import { CreateGameRoomDto } from 'src/api/game/dto/create-game-room.dto';
+import { isUUID } from 'class-validator';
+import { BadRequestException } from '@nestjs/common';
 
 @Controller('game')
 @ApiTags('game')
@@ -23,7 +21,7 @@ export class GameController {
 
   @UseGuards(AuthGuard('jwt'))
   @Get()
-  getGames(@Request() request): Promise<GameRoomDto[]> {
+  getGames(): Promise<GameRoomDto[]> {
     return this.gameService.getGames();
   }
 
@@ -43,6 +41,9 @@ export class GameController {
   ): Promise<GameRoomDto> {
     const leftUserId = request.user.id;
     const rightUserId = gameRoomData.invitedUserId;
+    if (!isUUID(leftUserId) || !isUUID(rightUserId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     return this.gameService.createGameRoom(leftUserId, rightUserId);
   }
 }

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -58,7 +58,7 @@ export class UserController {
   @ApiOperation({ summary: '로그인한 유저의 친구 목록' })
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
-  findFriends(@Req() req): Promise<Friend[]> {
+  findFriends(@Req() req) {
     const userId = req.user.id;
     return this.userService.findFriends(userId);
   }

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -24,6 +24,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { isUUID } from 'class-validator';
 import { BadRequestException } from '@nestjs/common';
 import { Friend } from '../../core/friend/friend.entity';
+import { Block } from '../../core/block/block.entity';
 
 @Controller('user')
 @ApiTags('user')
@@ -95,11 +96,20 @@ export class UserController {
   deleteFriend(@Param('frined-id') friendId: string) {}
   */
 
+  @Get('/block/')
+  @ApiOperation({ summary: '로그인한 유저의 차단 목록' })
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  getblockUsers(@Req() req): Promise<Block[]> {
+    const userId = req.user.id;
+    return this.userService.getblockUsers(userId);
+  }
+
   @Post('/block/:blockId')
   @ApiOperation({ summary: '로그인한 유저가 blockId를 차단' })
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
-  blockUser(@Req() req, @Param('blockId') blockId: string) {
+  blockUser(@Req() req, @Param('blockId') blockId: string): Promise<Block> {
     if (!isUUID(blockId)) {
       throw new BadRequestException('id가 uuid가 아님');
     }

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -72,6 +72,9 @@ export class UserController {
     @Req() req,
     @Param('friendId') friendId: string,
   ): Promise<Friend> {
+    if (!isUUID(friendId)) {
+      throw new BadRequestException('id가 uuid가 아님');
+    }
     const userId = req.user.id;
     return this.userService.requestFriend(userId, friendId);
   }

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -96,7 +96,7 @@ export class UserController {
   deleteFriend(@Param('frined-id') friendId: string) {}
   */
 
-  @Get('/block/')
+  @Get('/block')
   @ApiOperation({ summary: '로그인한 유저의 차단 목록' })
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
@@ -138,7 +138,7 @@ export class UserController {
     return this.userService.findChannelByParticipant(userId);
   }
 
-  @Get('channel/:channelId')
+  @Patch('channel/:channelId')
   @ApiOperation({ summary: '로그인한 유저가 초대받은 채널에 입장' })
   @UseGuards(AuthGuard('jwt'))
   @ApiParam({

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -134,10 +134,13 @@ export class UserController {
     name: 'id',
     type: 'string',
   })
-  findUserProfile(@Param('id') userId: string) {
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  findUserProfile(@Req() req, @Param('id') userId: string) {
     if (!isUUID(userId)) {
       throw new BadRequestException('id가 uuid가 아님');
     }
-    return this.userService.findUserProfile(userId);
+    const loginId = req.user.id;
+    return this.userService.userProfile(loginId, userId);
   }
 }

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -138,6 +138,22 @@ export class UserController {
     return this.userService.findChannelByParticipant(userId);
   }
 
+  @Get('channel/:channelId')
+  @ApiOperation({ summary: '로그인한 유저가 초대받은 채널에 입장' })
+  @UseGuards(AuthGuard('jwt'))
+  @ApiParam({
+    name: 'channelId',
+    type: 'string',
+  })
+  @ApiBearerAuth()
+  acceptChannelInvite(@Req() req, @Param('channelId') channelId: string) {
+    if (!isUUID(channelId)) {
+      throw new BadRequestException('uuid가 아님');
+    }
+    const userId = req.user.id;
+    return this.userService.acceptChannelInvite(userId, channelId);
+  }
+
   @Get(':id')
   @ApiOperation({ summary: '특정 유저 프로필 조회' })
   @ApiParam({

--- a/backend/src/api/user/user.service.ts
+++ b/backend/src/api/user/user.service.ts
@@ -184,6 +184,7 @@ export class UserService {
       where: {
         userId: { id: userId },
         leftAt: IsNull(),
+        joinAt: Not(IsNull()),
         channelId: { deletedAt: IsNull() },
       },
     });

--- a/backend/src/api/user/user.service.ts
+++ b/backend/src/api/user/user.service.ts
@@ -13,6 +13,7 @@ import { GameHistoryRepository } from '../../core/game/game-history.repository';
 import { GameHistory } from '../../core/game/game-history.entity';
 import { WinLose } from 'src/enum/win-lose.enum';
 import { FriendStatus } from '../../enum/friend-status';
+import { Block } from '../../core/block/block.entity';
 
 @Injectable()
 export class UserService {
@@ -138,6 +139,14 @@ export class UserService {
       acceptAt: () => 'CURRENT_TIMESTAMP',
     });
     return friendship;
+  }
+
+  async getblockUsers(userId: string): Promise<Block[]> {
+    const blocks = await this.blockRepository.find({
+      relations: ['userId', 'blockedUserId'],
+      where: { userId: { id: userId }, blockAt: Not(IsNull()) },
+    });
+    return blocks;
   }
 
   async blockUser(userId: string, blockId: string) {

--- a/backend/src/api/user/user.service.ts
+++ b/backend/src/api/user/user.service.ts
@@ -70,11 +70,27 @@ export class UserService {
     return user;
   }
 
-  async findFriends(userId: string): Promise<Friend[]> {
-    return await this.friendRespository.find({
+  async findFriends(userId: string) {
+    const friends = await this.friendRespository.find({
       relations: ['userId', 'userFriendId'],
-      where: [{ userId: { id: userId } }, { userFriendId: { id: userId } }],
+      where: [
+        { userId: { id: userId }, acceptAt: Not(IsNull()) },
+        { userFriendId: { id: userId }, acceptAt: Not(IsNull()) },
+      ],
     });
+    const receiveRequest = await this.friendRespository.find({
+      relations: ['userId', 'userFriendId'],
+      where: { userFriendId: { id: userId }, acceptAt: IsNull() },
+    });
+    const sendRequest = await this.friendRespository.find({
+      relations: ['userId', 'userFriendId'],
+      where: { userId: { id: userId }, acceptAt: IsNull() },
+    });
+    return {
+      friends: friends,
+      receiveRequest: receiveRequest,
+      sendRequest: sendRequest,
+    };
   }
 
   async requestFriend(userId: string, friendId: string): Promise<Friend> {

--- a/backend/src/core/channel/channel-member.entity.ts
+++ b/backend/src/core/channel/channel-member.entity.ts
@@ -29,6 +29,7 @@ export class ChannelMember extends Base {
   @Column({
     type: 'timestamp',
     default: () => 'CURRENT_TIMESTAMP',
+    nullable: true,
   })
   joinAt: Date;
 

--- a/backend/src/core/channel/channel-member.repository.ts
+++ b/backend/src/core/channel/channel-member.repository.ts
@@ -7,6 +7,30 @@ import { RoleInChannel } from '../../enum/role-in-channel.enum';
 
 @CustomRepository(ChannelMember)
 export class ChannelMemberRepository extends Repository<ChannelMember> {
+  async getIniviteChannels(userId: string) {
+    return await this.find({
+      relations: ['userId', 'channelId'],
+      where: {
+        userId: { id: userId },
+        joinAt: IsNull(),
+        banEndAt: IsNull() || LessThan(new Date()),
+        channelId: { deletedAt: IsNull() },
+      },
+    });
+  }
+
+  async findIniviteChannel(userId: string, channelId: string) {
+    return await this.findOne({
+      relations: ['userId', 'channelId'],
+      where: {
+        userId: { id: userId },
+        joinAt: IsNull(),
+        banEndAt: IsNull() || LessThan(new Date()),
+        channelId: { id: channelId, deletedAt: IsNull() },
+      },
+    });
+  }
+
   async getChannelsJoinCurrently(userId: string) {
     return await this.find({
       relations: ['userId', 'channelId'],

--- a/backend/src/core/channel/channel-member.repository.ts
+++ b/backend/src/core/channel/channel-member.repository.ts
@@ -12,6 +12,7 @@ export class ChannelMemberRepository extends Repository<ChannelMember> {
       relations: ['userId', 'channelId'],
       where: {
         userId: { id: userId },
+        joinAt: Not(IsNull()),
         leftAt: IsNull(),
         channelId: { deletedAt: IsNull() },
       },
@@ -23,6 +24,7 @@ export class ChannelMemberRepository extends Repository<ChannelMember> {
       relations: ['userId', 'channelId'],
       where: {
         userId: { id: userId },
+        joinAt: Not(IsNull()),
         leftAt: IsNull(),
         channelId: { id: channelId, deletedAt: IsNull() },
       },
@@ -34,6 +36,7 @@ export class ChannelMemberRepository extends Repository<ChannelMember> {
       relations: ['userId', 'channelId'],
       where: {
         userId: { id: userId },
+        joinAt: Not(IsNull()),
         leftAt: IsNull(),
         banEndAt: IsNull() || LessThan(new Date()),
         roleInChannel: RoleInChannel.OWNER || RoleInChannel.ADMINISTRATOR,
@@ -42,7 +45,7 @@ export class ChannelMemberRepository extends Repository<ChannelMember> {
     });
   }
 
-  async findChannelHaveJoin(userId: string, channelId: string) {
+  async findChannelHaveJoinOrInvite(userId: string, channelId: string) {
     return await this.findOne({
       relations: ['userId', 'channelId'],
       where: {
@@ -60,6 +63,7 @@ export class ChannelMemberRepository extends Repository<ChannelMember> {
       },
       where: {
         leftAt: IsNull(),
+        joinAt: Not(IsNull()),
         banEndAt: IsNull() || LessThan(new Date()),
         roleInChannel: RoleInChannel.ADMINISTRATOR,
         channelId: { id: channelId, deletedAt: IsNull() },
@@ -75,6 +79,7 @@ export class ChannelMemberRepository extends Repository<ChannelMember> {
       },
       where: {
         leftAt: IsNull(),
+        joinAt: Not(IsNull()),
         banEndAt: IsNull() || LessThan(new Date()),
         roleInChannel: Not(RoleInChannel.OWNER),
         channelId: { id: channelId, deletedAt: IsNull() },
@@ -87,6 +92,7 @@ export class ChannelMemberRepository extends Repository<ChannelMember> {
       relations: ['userId', 'channelId'],
       where: {
         leftAt: IsNull(),
+        joinAt: Not(IsNull()),
         channelId: { id: channelId },
       },
     });

--- a/backend/src/enum/friend-status.ts
+++ b/backend/src/enum/friend-status.ts
@@ -1,0 +1,6 @@
+export enum FriendStatus {
+  ALREADY = 'ALREADY',
+  SEND = 'SEND',
+  RECEIVE = 'RECEIVE',
+  NONE = 'NONE',
+}

--- a/backend/src/enum/role-in-channel.enum.ts
+++ b/backend/src/enum/role-in-channel.enum.ts
@@ -2,5 +2,5 @@ export enum RoleInChannel {
   OWNER = 'OWNER',
   ADMINISTRATOR = 'ADMINISTRATOR',
   NORMAL = 'NORMAL',
-  BLOCK = 'BLOCK',
+  //   BLOCK = 'BLOCK',
 }


### PR DESCRIPTION
## Description
채널에 유저 초대하기 기능, 초대 수락 기능 추가 및 기타 api를 수정합니다

## Todo
- 채널에 유저 초대하는 기능 만들기 ->  `POST /api/channel/{channel_id}/invite/{user_id}` 추가
  - 초대 수락 기능도 필요 -> `PATCH /api/user/channel/{channelId}` 추가
  - `GET /api/user/channel` 에서 초대받은 채널 목록도 볼 수 있게 됨
  - 초대 받은 상태는 `join_at` 의 `null` 여부로 판단합니다
- 채널에서 ban 하는 것과 block 하는 것 합치기
  - `PATCH /api/channel/{channel_id}/ban/{user_id}` 수정
  - `PATCH /api/channel/{channel_id}/block/{user_id}` 삭제, ban api 에 흡수
  - 사용자는 ban을 당하는 순간 채널에서 강퇴 당한다
- 특정 유저의 프로필을 조회할때 그 유저가 나와 친구인지, 내가 차단한 상대인지 알 수 있는 항목을 보내주기
  - `GET /api/user/{id}` 수정
  - `receiveRequest`, `sendRequest` 항목 추가, 자기자신을 조회할 경우 두 항목 모두 `null`
- 친구 목록을 서로 친구인 경우, 내가 친구 요청을 보낸 경우, 상대가 요청을 보낸 경우로 나누기
  - `GET /api/user/friend` 수정
  - 상대가 요청을 보낸 경우일때 친구 수락 api 로 친구가 될 수 있음
- 로그인한 유저의 차단 목록을 불러오기 -> `GET /api/user/block` 추가