### PR TITLE
Feat/#31 클린코드, live&leaderboard페이지, ladder점수 개혁

### DIFF
--- a/backend/src/core/game/game-queue.repository.ts
+++ b/backend/src/core/game/game-queue.repository.ts
@@ -82,11 +82,11 @@ export class GameQueueRepository {
   }
 
   async checkQue(myId: string, _wait: number): Promise<Game> {
-    let myLadder = -1;
+    let myLevel = -1;
     let myidx = 0;
     for (let i = 0; this.gameQue[i]; i++) {
       if (myId == this.gameQue[i].userId) {
-        myLadder = this.gameQue[i].ladder;
+        myLevel = this.gameQue[i].ladder / 10;
         myidx = i;
       }
     }
@@ -95,9 +95,12 @@ export class GameQueueRepository {
         continue;
       if (
         this.gameQue[myidx].mode == this.gameQue[idx].mode &&
-        _wait >= Math.abs(myLadder - this.gameQue[idx].ladder) &&
-        this.gameQue[idx].wait >= Math.abs(myLadder - this.gameQue[idx].ladder)
+        _wait > Math.abs(myLevel - this.gameQue[idx].ladder / 10) - 1 &&
+        this.gameQue[idx].wait >
+          Math.abs(myLevel - this.gameQue[idx].ladder / 10) - 1
       ) {
+        // Matching!!
+        console.log(`me:${myLevel} vs ${this.gameQue[idx].ladder / 10}`);
         clearTimeout(this.getQueLoop(myidx));
         clearTimeout(this.getQueLoop(idx));
         const leftUser = await this.userRepository.findOneBy({

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -50,7 +50,13 @@ export default function Header({ title }: any) {
           >
             live
           </Button>
-          <Button>leaderboard</Button>
+          <Button
+            onClick={() => {
+              router.push(`/leaderboard`);
+            }}
+          >
+            leaderboard
+          </Button>
         </Grid>
         <Grid item xs={12} md={3}>
           <Stack direction="row" spacing={2} alignItems="center">

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -43,7 +43,13 @@ export default function Header({ title }: any) {
           <Box sx={{ display: "inline", flex: 1 }}>
             <MatchingModal />
           </Box>
-          <Button>live</Button>
+          <Button
+            onClick={() => {
+              router.push(`/live`);
+            }}
+          >
+            live
+          </Button>
           <Button>leaderboard</Button>
         </Grid>
         <Grid item xs={12} md={3}>

--- a/frontend/components/InviteModal.tsx
+++ b/frontend/components/InviteModal.tsx
@@ -303,7 +303,6 @@ export function MatchingModal() {
   const router = useRouter();
 
   socket.on("goToGameRoom", (roomId) => {
-    // user_data.is_player = 1;
     router.push(`/game/${roomId}`);
   });
 

--- a/frontend/components/Profile.tsx
+++ b/frontend/components/Profile.tsx
@@ -18,6 +18,7 @@ export default function Profile({ userName }: any) {
   const router = useRouter();
   const me = getLoginUser();
   //   const [user, setUser]: any = useState({});
+  const [userLadder, setUserLadder]: any = useState(0);
   const [history, setHistory]: any = useState({});
   const [testHistory, setTestHistory]: any[] = useState([]);
   const [inviteModal, setInviteModal] = useState(<></>);
@@ -32,6 +33,7 @@ export default function Profile({ userName }: any) {
         // setUser(...res.data);
         // setUser(res.data[0]);
         const user = res.data[0];
+        setUserLadder(user.ladder);
         console.log(`user:`);
         console.log(user);
         console.log(`${me.username} vs ${userName}`);
@@ -116,7 +118,7 @@ export default function Profile({ userName }: any) {
         {inviteModal}
         <br />
         <Typography variant="h5" gutterBottom>
-          {/* ladder: {user.ladder} <br /> <br /> History */}
+          ladder: {userLadder} <br /> <br /> History
         </Typography>
         {testHistory}
       </Box>

--- a/frontend/lib/login.ts
+++ b/frontend/lib/login.ts
@@ -18,7 +18,9 @@ export function useLoginGuard() {
 }
 
 export async function logout() {
-  await axios.post("/server/api/auth/logout");
+  await axios.post("/server/api/auth/logout").catch((e) => {
+    console.error(e);
+  });
   window.localStorage.removeItem("loginUser");
 }
 

--- a/frontend/pages/clients.tsx
+++ b/frontend/pages/clients.tsx
@@ -249,13 +249,6 @@ function GoToGameRoom({ gameRoom }: any) {
     console.log(`come in room~`);
     console.log(gameRoom.leftUser.id);
     console.log(gameRoom.rightUser.id);
-    // console.log(user_data._id);
-    // if (
-    //   gameRoom.leftUser.id == user_data._id ||
-    //   gameRoom.rightUser.id == user_data._id
-    // ) {
-    //   user_data.is_player = 1;
-    // }
 
     router.push(`/game/${gameRoom.id}`);
   }

--- a/frontend/pages/clients.tsx
+++ b/frontend/pages/clients.tsx
@@ -1,7 +1,6 @@
 import Router, { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import axios from "axios";
-import { user_data } from "./login";
 import { socket, useSocketAuthorization } from "../lib/socket";
 import { logout, getLoginUser } from "../lib/login";
 import Layout from "../components/Layout";
@@ -15,6 +14,9 @@ import {
 export default function Client() {
   useSocketAuthorization();
   const router = useRouter();
+  let myName: any;
+  let dmRooms: any[] = [];
+  let gameRooms: any[] = [];
 
   let [dmRoomList, setDmRoomList]: any = useState([]);
   useEffect(getDmRooms, [router.isReady]);
@@ -27,21 +29,14 @@ export default function Client() {
   useEffect(() => {
     if (!router.isReady) return;
 
-    user_data._name = getLoginUser().username;
-    console.log(user_data._name);
+    myName = getLoginUser().username;
+    console.log(myName);
     function goToGameRoom(roomId: number) {
       router.push(`/game/${roomId}`);
     }
     function gameInvited(inviterId: string) {
       console.log(`you got mail~`);
-      // if (confirm(`invited by ${inviterId}\nplaying?`) == true) {
-      //   user_data.is_player = 1;
-      //   socket.emit('acceptFriendQue', inviterId);
-      //   socket.off(`acceptFriendQue`,);
-      // }
-      // else {}
     }
-    user_data.is_player = 0;
     socket.on("goToGameRoom", goToGameRoom);
     socket.on("gameInvited", gameInvited);
 
@@ -61,9 +56,9 @@ export default function Client() {
     axios
       .get("/server/api/dm")
       .then(function (response) {
-        user_data._room = response.data;
+        dmRooms = response.data;
         let newDmRoomList = [];
-        for (let dmRoom of user_data._room)
+        for (let dmRoom of dmRooms)
           newDmRoomList.push(<GoToDmRoom key={dmRoom.id} dmRoom={dmRoom} />);
         setDmRoomList(newDmRoomList);
       })
@@ -77,8 +72,8 @@ export default function Client() {
     axios
       .get("/server/api/game")
       .then(function (response) {
-        user_data.game_room = response.data;
-        for (let gameRoom of user_data.game_room)
+        gameRooms = response.data;
+        for (let gameRoom of gameRooms)
           newGameRoomList.push(
             <GoToGameRoom key={gameRoom.id} gameRoom={gameRoom} />
           );
@@ -96,7 +91,6 @@ export default function Client() {
             onClick={() => {
               socket.emit("acceptFriendQue", que.inviterId);
               socket.off(`acceptFriendQue`);
-              user_data.is_player = 1;
             }}
           >
             {" "}
@@ -170,10 +164,10 @@ export default function Client() {
   return (
     <Layout>
       <h1>
-        HI {user_data._name}
+        HI {myName}
         <button
           onClick={() => {
-            router.push(`/profile/${user_data._name}`);
+            router.push(`/profile/${myName}`);
           }}
         >
           <h1> 프로필 </h1>
@@ -255,13 +249,13 @@ function GoToGameRoom({ gameRoom }: any) {
     console.log(`come in room~`);
     console.log(gameRoom.leftUser.id);
     console.log(gameRoom.rightUser.id);
-    console.log(user_data._id);
-    if (
-      gameRoom.leftUser.id == user_data._id ||
-      gameRoom.rightUser.id == user_data._id
-    ) {
-      user_data.is_player = 1;
-    }
+    // console.log(user_data._id);
+    // if (
+    //   gameRoom.leftUser.id == user_data._id ||
+    //   gameRoom.rightUser.id == user_data._id
+    // ) {
+    //   user_data.is_player = 1;
+    // }
 
     router.push(`/game/${gameRoom.id}`);
   }

--- a/frontend/pages/dm.tsx
+++ b/frontend/pages/dm.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import axios from "axios";
-import { user_data } from "./login";
 import { dmSocket } from "../sockets/sockets";
 import Link from "next/link";
 import Layout from "../components/Layout";
@@ -9,6 +8,7 @@ import Layout from "../components/Layout";
 export default function Dm() {
   const router = useRouter();
   const [invitedUser, setInvitedUser] = useState({ id: null, username: null });
+  let dmRooms: any[] = [];
 
   const [dmRoomList, setDmRoomList]: any = useState([]);
   useEffect(getDmRooms, []);
@@ -17,7 +17,7 @@ export default function Dm() {
     axios
       .get("/server/api/dm")
       .then(function (response) {
-        user_data._room = response.data;
+        dmRooms = response.data;
         const newDmRoomList = response.data;
         setDmRoomList(newDmRoomList);
         dmSocket.emit("dmRooms", newDmRoomList);

--- a/frontend/pages/game/[room_id].tsx
+++ b/frontend/pages/game/[room_id].tsx
@@ -1,5 +1,4 @@
 import { socket, useSocketAuthorization } from "../../lib/socket";
-import { user_data } from "../login";
 import axios from "axios";
 import { Router, useRouter } from "next/router";
 import React, { useEffect } from "react";

--- a/frontend/pages/leaderboard.tsx
+++ b/frontend/pages/leaderboard.tsx
@@ -1,0 +1,67 @@
+import Router, { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { socket } from "../lib/socket";
+import Layout from "../components/Layout";
+import { Button, Typography } from "@mui/material";
+
+export default function LeaderBoard() {
+  const router = useRouter();
+  let users: any[] = [];
+  useEffect(getUsers, [router.isReady]);
+  const [UserList, setUserList]: any = useState([]);
+
+  function getUsers() {
+    if (!router.isReady) return;
+    let newUserList: any[] = [];
+    axios
+      .get("/server/api/user")
+      .then(function (response) {
+        users = response.data.sort(function (a: any, b: any) {
+          return b.ladder - a.ladder;
+        });
+        console.log(users);
+        for (let User of users)
+          newUserList.push(<GoToUser key={User.id} User={User} />);
+        setUserList(newUserList);
+      })
+      .catch(() => {
+        // router.push("/login");
+      });
+
+    return () => {
+      socket.off(`invitedQue`);
+    };
+  }
+
+  return (
+    <Layout>
+      <Typography> LeaderBoard </Typography>
+      <Button
+        onClick={() => {
+          getUsers;
+        }}
+      >
+        reset
+      </Button>
+      {UserList}
+    </Layout>
+  );
+}
+
+function GoToUser({ User }: any) {
+  let router = useRouter();
+  let result: JSX.Element[] = [];
+
+  function onClickUser() {
+    router.push(`/profile/${User.username}`);
+  }
+
+  return (
+    <div>
+      <button onClick={onClickUser}>
+        {User.username} {"ladder: "} {User.ladder}
+      </button>
+    </div>
+  );
+}

--- a/frontend/pages/live.tsx
+++ b/frontend/pages/live.tsx
@@ -36,7 +36,6 @@ export default function Live() {
             onClick={() => {
               socket.emit("acceptFriendQue", que.inviterId);
               socket.off(`acceptFriendQue`);
-              //   user_data.is_player = 1;
             }}
           >
             {que.inviterName}
@@ -74,13 +73,6 @@ function GoToGameRoom({ gameRoom }: any) {
     console.log(`come in room~`);
     console.log(gameRoom.leftUser.id);
     console.log(gameRoom.rightUser.id);
-    // console.log(user_data._id);
-    // if (
-    //   gameRoom.leftUser.id == user_data._id ||
-    //   gameRoom.rightUser.id == user_data._id
-    // ) {
-    //   user_data.is_player = 1;
-    // }
 
     router.push(`/game/${gameRoom.id}`);
   }

--- a/frontend/pages/live.tsx
+++ b/frontend/pages/live.tsx
@@ -1,0 +1,95 @@
+import Router, { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { socket } from "../lib/socket";
+import Layout from "../components/Layout";
+import { Button, Typography } from "@mui/material";
+
+export default function Live() {
+  const router = useRouter();
+  let gameRooms: any[] = [];
+  useEffect(getGameRooms, [router.isReady]);
+  const [gameRoomList, setGameRoomList]: any = useState([]);
+
+  function getGameRooms() {
+    if (!router.isReady) return;
+    let newGameRoomList: any[] = [];
+    axios
+      .get("/server/api/game")
+      .then(function (response) {
+        gameRooms = response.data;
+        for (let gameRoom of gameRooms)
+          newGameRoomList.push(
+            <GoToGameRoom key={gameRoom.id} gameRoom={gameRoom} />
+          );
+        setGameRoomList(newGameRoomList);
+      })
+      .catch(() => {
+        // router.push("/login");
+      });
+    socket.emit("giveMeInvited");
+    socket.on(`invitedQue`, (ques) => {
+      for (let que of ques) {
+        newGameRoomList.push(
+          <Button
+            key={que.inviterId}
+            onClick={() => {
+              socket.emit("acceptFriendQue", que.inviterId);
+              socket.off(`acceptFriendQue`);
+              //   user_data.is_player = 1;
+            }}
+          >
+            {que.inviterName}
+          </Button>
+        );
+      }
+      setGameRoomList(...newGameRoomList);
+    });
+
+    return () => {
+      socket.off(`invitedQue`);
+    };
+  }
+
+  return (
+    <Layout>
+      <Typography> LIVE </Typography>
+      <Button
+        onClick={() => {
+          getGameRooms;
+        }}
+      >
+        reset
+      </Button>
+      {gameRoomList}
+    </Layout>
+  );
+}
+
+function GoToGameRoom({ gameRoom }: any) {
+  let router = useRouter();
+  let result: JSX.Element[] = [];
+
+  function onClickGameRoom() {
+    console.log(`come in room~`);
+    console.log(gameRoom.leftUser.id);
+    console.log(gameRoom.rightUser.id);
+    // console.log(user_data._id);
+    // if (
+    //   gameRoom.leftUser.id == user_data._id ||
+    //   gameRoom.rightUser.id == user_data._id
+    // ) {
+    //   user_data.is_player = 1;
+    // }
+
+    router.push(`/game/${gameRoom.id}`);
+  }
+
+  return (
+    <div>
+      <button onClick={onClickGameRoom}>
+        {gameRoom.leftUser.username} VS {gameRoom.rightUser.username}
+      </button>
+    </div>
+  );
+}

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -9,14 +9,14 @@ import axios from "axios";
 import { io, Socket } from "socket.io-client";
 import { socket } from "../lib/socket";
 import { isLoggedIn } from "../lib/login";
+import { Box, Button, FormControl, TextField, Typography } from "@mui/material";
 
-export let user_data: any = {
+let user_data: any = {
   _name: "",
   _pass: "",
   _socket: "",
   _token: "",
   _room: [],
-  is_player: 0,
 };
 
 export default function Login() {
@@ -59,14 +59,22 @@ export default function Login() {
   }
 
   return (
-    <div>
-      <form onSubmit={onSubmitHandler}>
-        <input type="text" id="username" name="username" />
-        <br />
-        <input type="text" id="password" name="password" />
-        <br />
-        <button type="submit">Login</button>
-      </form>
-    </div>
+    <Box component="form" onSubmit={onSubmitHandler}>
+      <Typography>Login</Typography>
+      <FormControl>
+        <TextField variant="outlined" name="username"></TextField>
+        <TextField variant="outlined" name="password"></TextField>
+      </FormControl>
+      <Button type="submit">Login</Button>
+    </Box>
+    // <div>
+    //   <form onSubmit={onSubmitHandler}>
+    //     <input type="text" id="username" name="username" />
+    //     <br />
+    //     <input type="text" id="password" name="password" />
+    //     <br />
+    //     <button type="submit">Login</button>
+    //   </form>
+    // </div>
   );
 }

--- a/frontend/pages/matching.tsx
+++ b/frontend/pages/matching.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from "next/router";
-import { user_data } from "./login";
 import { socket, useSocketAuthorization } from "../lib/socket";
 import { useEffect } from "react";
 import Layout from "../components/Layout";
@@ -13,7 +12,6 @@ export default function matching() {
     }
     router.events.on("routeChangeStart", routeChangeHandler);
     socket.on("goToGameRoom", (roomId) => {
-      user_data.is_player = 1;
       router.push(`/game/${roomId}`);
     });
 

--- a/frontend/pages/profile/[user_name].tsx
+++ b/frontend/pages/profile/[user_name].tsx
@@ -1,7 +1,6 @@
 import Router, { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import axios from "axios";
-import { user_data } from "../login";
 import { socket, useSocketAuthorization } from "../../lib/socket";
 import { logout, getLoginUser } from "../../lib/login";
 import Layout from "../../components/Layout";


### PR DESCRIPTION
live, leaderboard는 최소한의 구현만 해놓았습니다,
ladder점수는
0~9 -> ladder: 1
10~19 -> ladder: 2
이런식으로 ladder 레벨을 나누었습니다.
승리시마다 1점, 패배시 -1점, 0점아래로 가진않습니다.